### PR TITLE
Return stub store when asking for nonexistent:

### DIFF
--- a/lib/app-registry.js
+++ b/lib/app-registry.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Reflux = require('reflux');
 const Action = require('./actions');
 
 /**
@@ -8,6 +9,12 @@ const Action = require('./actions');
  * that we would expect.
  */
 const INT8_MAX = 127;
+
+/**
+ * Returning a fake store when asking for a store that does not
+ * exist.
+ */
+const STUB_STORE = Reflux.createStore();
 
 /**
  * Is a registry for all user interface components, stores, and actions
@@ -43,6 +50,7 @@ class AppRegistry {
     this.stores = {};
     this.containers = {};
     this.roles = {};
+    this.storeMisses = {};
   }
 
   /**
@@ -166,7 +174,12 @@ class AppRegistry {
    * @returns {Store} The store.
    */
   getStore(name) {
-    return this.stores[name];
+    const store = this.stores[name];
+    if (store === undefined) {
+      this.storeMisses[name] = (this.storeMisses[name] || 0) + 1;
+      return STUB_STORE;
+    }
+    return store;
   }
 
   /**

--- a/test/app-registry.test.js
+++ b/test/app-registry.test.js
@@ -7,6 +7,44 @@ const Action = require('../lib/actions');
 const AppRegistry = require('../lib/app-registry');
 
 describe('AppRegistry', () => {
+  describe('getStore', () => {
+    context('when the store does not exist', () => {
+      const registry = new AppRegistry();
+      let storeLike;
+
+      before(() => {
+        storeLike = registry.getStore('Test.Store');
+      });
+
+      it('does not return undefined', () => {
+        expect(storeLike).to.not.equal(undefined);
+      });
+
+      it('returns a store-like object', (done) => {
+        const unsubscribe = storeLike.listen((value) => {
+          expect(value).to.equal('test');
+          unsubscribe();
+          done();
+        });
+        storeLike.trigger('test');
+      });
+
+      it('flags the non-existant request', () => {
+        expect(registry.storeMisses['Test.Store']).to.equal(1);
+      });
+
+      context('when asking for a missing store more than once', () => {
+        before(() => {
+          registry.getStore('Test.Store');
+        });
+
+        it('updates the miss count', () => {
+          expect(registry.storeMisses['Test.Store']).to.equal(2);
+        });
+      });
+    });
+  });
+
   describe('#onActivated', () => {
     context('when the method is defined on the store', () => {
       let registry;


### PR DESCRIPTION
When the app registry is asked for a store that doesn't exist, its
previous behaviour was to return undefined. This could cause plugins
with issues to break the application because listen was not available to
be called by other plugins. Instead, we now return a fake store that can
be listened to so the application does not error. The app registry can
then be examined to see all names of stores that we asked for but were
missing and the number of times they were requested.